### PR TITLE
Travisctests

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,8 @@ A pointer to a pointer is however left alone and just introduces minor wrapping.
 
 ## Testing
 
-Identity properties are tested with QuickCheck to ensure that peek and poke are reversible. Imports from C are tested in ```CTest.hs``` and form together with the identity tests the guarantee that also exports to C are consistent.
+Identity properties are tested with QuickCheck to ensure that peek and poke are reversible. Imports from C are tested in ```test/CTest.hs``` and form together with the identity tests the guarantee that also exports to C are consistent.
 The QuickCheck tests are performed for all latest minor revisions of GHC versions >= 8.0 through [haskell-ci](https://github.com/haskell-CI/haskell-ci). More GHC versions will be added once the C-structs package is available through Hackage.
-The C-tests currently fail on travis and are only performed on branch "travisctests".
 
 Further testing is done in the [```Hasky```](https://github.com/pinselimo/Hasky) packages where correct interfacing with Python is ensured.
 

--- a/test/CTest.hs
+++ b/test/CTest.hs
@@ -17,9 +17,11 @@ quick = unsafePerformIO
 foreign import ccall "arrayDouble" arrayDouble :: CArray CDouble
 foreign import ccall "arrayInt" arrayInt :: CArray CInt
 foreign import ccall "arrayFloat" arrayFloat :: CArray CFloat
+{-
 foreign import ccall "listDouble" listDouble :: CList CDouble
 foreign import ccall "listInt" listInt :: CList CInt
 foreign import ccall "listFloat" listFloat :: CList CFloat
+-}
 
 fibs = 1.0 : 2.0 : zipWith (+) fibs (tail fibs) :: [CDouble]
 doubles = take 63 fibs :: [CDouble]
@@ -39,10 +41,10 @@ pfl list = do
     return l
 
 tests = testGroup "Foreign Imports" [
-        testCase "arrayDouble" $ (quick $ pfa arrayDouble) @?= doubles,
-        testCase "arrayInt"    $ (quick $ pfa arrayInt)    @?= ints,
-        testCase "arrayFloat"  $ (quick $ pfa arrayFloat)  @?= floats,
-        testCase "listDouble"  $ (quick $ pfl listDouble)   @?= doubles,
-        testCase "listInt"     $ (quick $ pfl listInt)      @?= ints,
-        testCase "listFloat"   $ (quick $ pfl listFloat )   @?= floats
-    ]
+        testCase "arrayDouble" $ (quick $ pfa arrayDouble) @?= doubles
+      , testCase "arrayInt"    $ (quick $ pfa arrayInt)    @?= ints
+      , testCase "arrayFloat"  $ (quick $ pfa arrayFloat)  @?= floats
+--      , testCase "listDouble"  $ (quick $ pfl listDouble)   @?= doubles
+--      , testCase "listInt"     $ (quick $ pfl listInt)      @?= ints
+--      , testCase "listFloat"   $ (quick $ pfl listFloat )   @?= floats
+   ]

--- a/test/CTest.hs
+++ b/test/CTest.hs
@@ -4,15 +4,15 @@ module CTest where
 import Test.Tasty (testGroup)
 import Test.Tasty.HUnit (testCase, (@?=))
 
-import System.IO.Unsafe (unsafePerformIO)
-
 import Foreign.C.Types
 import Foreign.Ptr
 import Foreign.Storable
 import Foreign.Hasky.Array
 import Foreign.Hasky.List
 
-quick = unsafePerformIO
+check list action = do
+    list' <- action
+    list @?= list'
 
 foreign import ccall "arrayDouble" arrayDouble :: CArray CDouble
 foreign import ccall "arrayInt" arrayInt :: CArray CInt
@@ -40,10 +40,10 @@ pfl list = do
     return l
 
 tests = testGroup "Foreign Imports" [
-        testCase "arrayDouble" $ (quick $ pfa arrayDouble) @?= doubles
-      , testCase "arrayInt"    $ (quick $ pfa arrayInt)    @?= ints
-      , testCase "arrayFloat"  $ (quick $ pfa arrayFloat)  @?= floats
+        testCase "arrayDouble" $ check doubles (pfa arrayDouble)
+      , testCase "arrayInt"    $ check ints    (pfa arrayInt)
+      , testCase "arrayFloat"  $ check floats  (pfa arrayFloat)
 --      , testCase "listDouble"  $ (quick $ pfl listDouble)   @?= doubles
-      , testCase "listInt"     $ (quick $ pfl listInt)      @?= ints
+      , testCase "listInt"     $ check ints    (pfl listInt)
 --      , testCase "listFloat"   $ (quick $ pfl listFloat )   @?= floats
    ]

--- a/test/CTest.hs
+++ b/test/CTest.hs
@@ -7,6 +7,7 @@ import Test.Tasty.HUnit (testCase, (@?=))
 import Foreign.C.Types
 import Foreign.Ptr
 import Foreign.Storable
+import Foreign.Marshal.Alloc (free)
 import Foreign.Hasky.Array
 import Foreign.Hasky.List
 
@@ -18,9 +19,9 @@ foreign import ccall "arrayDouble" arrayDouble :: CArray CDouble
 foreign import ccall "arrayInt" arrayInt :: CArray CInt
 foreign import ccall "arrayFloat" arrayFloat :: CArray CFloat
 
--- foreign import ccall "listDouble" listDouble :: CList CDouble
+foreign import ccall "listDouble" listDouble :: CList CDouble
 foreign import ccall "listInt" listInt :: CList CInt
--- foreign import ccall "listFloat" listFloat :: CList CFloat
+foreign import ccall "listFloat" listFloat :: CList CFloat
 
 fibs = 1.0 : 2.0 : zipWith (+) fibs (tail fibs) :: [CDouble]
 doubles = take 63 fibs :: [CDouble]
@@ -36,14 +37,14 @@ pfa arr = do
 pfl :: Storable a => CList a -> IO [a]
 pfl list = do
     l <- peekList list
-    freeList list
+    free list
     return l
 
 tests = testGroup "Foreign Imports" [
         testCase "arrayDouble" $ check doubles (pfa arrayDouble)
       , testCase "arrayInt"    $ check ints    (pfa arrayInt)
       , testCase "arrayFloat"  $ check floats  (pfa arrayFloat)
---      , testCase "listDouble"  $ (quick $ pfl listDouble)   @?= doubles
+      , testCase "listDouble"  $ check doubles (pfl listDouble)
       , testCase "listInt"     $ check ints    (pfl listInt)
 --      , testCase "listFloat"   $ (quick $ pfl listFloat )   @?= floats
    ]

--- a/test/CTest.hs
+++ b/test/CTest.hs
@@ -23,6 +23,16 @@ foreign import ccall "listDouble" listDouble :: CList CDouble
 foreign import ccall "listInt" listInt :: CList CInt
 foreign import ccall "listFloat" listFloat :: CList CFloat
 
+-- The many calls to malloc in the conventional list examples make cabal
+-- fail on Travis-CI. Which is why special examples were added using a
+-- single call to malloc to allocate the entire space needed for the list.
+-- CList however, doesn't require the list to sit in one continuous space.
+-- In fact, 'newList' will itself issue multiple calls to malloc (via 'new').
+foreign import ccall "listDoubleTravis" listDoubleTravis :: CList CDouble
+foreign import ccall "listIntTravis" listIntTravis :: CList CInt
+foreign import ccall "listFloatTravis" listFloatTravis :: CList CFloat
+
+
 fibs = 1.0 : 2.0 : zipWith (+) fibs (tail fibs) :: [CDouble]
 doubles = take 63 fibs :: [CDouble]
 ints = [0..41] :: [CInt]
@@ -37,6 +47,14 @@ pfa arr = do
 pfl :: Storable a => CList a -> IO [a]
 pfl list = do
     l <- peekList list
+    freeList list
+    return l
+
+-- Since the travis examples are allocated in one malloc call
+-- they have to be released with "free"
+pft :: Storable a => CList a -> IO [a]
+pft list = do
+    l <- peekList list
     free list
     return l
 
@@ -46,5 +64,8 @@ tests = testGroup "Foreign Imports" [
       , testCase "arrayFloat"  $ check floats  (pfa arrayFloat)
       , testCase "listDouble"  $ check doubles (pfl listDouble)
       , testCase "listInt"     $ check ints    (pfl listInt)
---      , testCase "listFloat"   $ (quick $ pfl listFloat )   @?= floats
+      , testCase "listFloat"   $ check floats  (pfl listFloat)
+      , testCase "listDoubleTravis"  $ check doubles (pft listDoubleTravis)
+      , testCase "listIntTravis"     $ check ints    (pft listIntTravis)
+      , testCase "listFloatTravis"   $ check floats  (pft listFloatTravis)
    ]

--- a/test/CTest.hs
+++ b/test/CTest.hs
@@ -23,15 +23,6 @@ foreign import ccall "listDouble" listDouble :: CList CDouble
 foreign import ccall "listInt" listInt :: CList CInt
 foreign import ccall "listFloat" listFloat :: CList CFloat
 
--- The many calls to malloc in the conventional list examples make cabal
--- fail on Travis-CI. Which is why special examples were added using a
--- single call to malloc to allocate the entire space needed for the list.
--- CList however, doesn't require the list to sit in one continuous space.
--- In fact, 'newList' will itself issue multiple calls to malloc (via 'new').
-foreign import ccall "listDoubleTravis" listDoubleTravis :: CList CDouble
-foreign import ccall "listIntTravis" listIntTravis :: CList CInt
-foreign import ccall "listFloatTravis" listFloatTravis :: CList CFloat
-
 
 fibs = 1.0 : 2.0 : zipWith (+) fibs (tail fibs) :: [CDouble]
 doubles = take 63 fibs :: [CDouble]
@@ -50,14 +41,6 @@ pfl list = do
     freeList list
     return l
 
--- Since the travis examples are allocated in one malloc call
--- they have to be released with "free"
-pft :: Storable a => CList a -> IO [a]
-pft list = do
-    l <- peekList list
-    free list
-    return l
-
 tests = testGroup "Foreign Imports" [
         testCase "arrayDouble" $ check doubles (pfa arrayDouble)
       , testCase "arrayInt"    $ check ints    (pfa arrayInt)
@@ -65,7 +48,4 @@ tests = testGroup "Foreign Imports" [
       , testCase "listDouble"  $ check doubles (pfl listDouble)
       , testCase "listInt"     $ check ints    (pfl listInt)
       , testCase "listFloat"   $ check floats  (pfl listFloat)
-      , testCase "listDoubleTravis"  $ check doubles (pft listDoubleTravis)
-      , testCase "listIntTravis"     $ check ints    (pft listIntTravis)
-      , testCase "listFloatTravis"   $ check floats  (pft listFloatTravis)
    ]

--- a/test/CTest.hs
+++ b/test/CTest.hs
@@ -17,11 +17,10 @@ quick = unsafePerformIO
 foreign import ccall "arrayDouble" arrayDouble :: CArray CDouble
 foreign import ccall "arrayInt" arrayInt :: CArray CInt
 foreign import ccall "arrayFloat" arrayFloat :: CArray CFloat
-{-
-foreign import ccall "listDouble" listDouble :: CList CDouble
+
+-- foreign import ccall "listDouble" listDouble :: CList CDouble
 foreign import ccall "listInt" listInt :: CList CInt
-foreign import ccall "listFloat" listFloat :: CList CFloat
--}
+-- foreign import ccall "listFloat" listFloat :: CList CFloat
 
 fibs = 1.0 : 2.0 : zipWith (+) fibs (tail fibs) :: [CDouble]
 doubles = take 63 fibs :: [CDouble]
@@ -45,6 +44,6 @@ tests = testGroup "Foreign Imports" [
       , testCase "arrayInt"    $ (quick $ pfa arrayInt)    @?= ints
       , testCase "arrayFloat"  $ (quick $ pfa arrayFloat)  @?= floats
 --      , testCase "listDouble"  $ (quick $ pfl listDouble)   @?= doubles
---      , testCase "listInt"     $ (quick $ pfl listInt)      @?= ints
+      , testCase "listInt"     $ (quick $ pfl listInt)      @?= ints
 --      , testCase "listFloat"   $ (quick $ pfl listFloat )   @?= floats
    ]

--- a/test/CTest.hs
+++ b/test/CTest.hs
@@ -11,10 +11,6 @@ import Foreign.Marshal.Alloc (free)
 import Foreign.Hasky.Array
 import Foreign.Hasky.List
 
-check list action = do
-    list' <- action
-    list @?= list'
-
 foreign import ccall "arrayDouble" arrayDouble :: CArray CDouble
 foreign import ccall "arrayInt" arrayInt :: CArray CInt
 foreign import ccall "arrayFloat" arrayFloat :: CArray CFloat
@@ -22,7 +18,6 @@ foreign import ccall "arrayFloat" arrayFloat :: CArray CFloat
 foreign import ccall "listDouble" listDouble :: CList CDouble
 foreign import ccall "listInt" listInt :: CList CInt
 foreign import ccall "listFloat" listFloat :: CList CFloat
-
 
 fibs = 1.0 : 2.0 : zipWith (+) fibs (tail fibs) :: [CDouble]
 doubles = take 63 fibs :: [CDouble]
@@ -42,10 +37,10 @@ pfl list = do
     return l
 
 tests = testGroup "Foreign Imports" [
-        testCase "arrayDouble" $ check doubles (pfa arrayDouble)
-      , testCase "arrayInt"    $ check ints    (pfa arrayInt)
-      , testCase "arrayFloat"  $ check floats  (pfa arrayFloat)
-      , testCase "listDouble"  $ check doubles (pfl listDouble)
-      , testCase "listInt"     $ check ints    (pfl listInt)
-      , testCase "listFloat"   $ check floats  (pfl listFloat)
+        testCase "arrayDouble" $ (pfa arrayDouble) >>= (@?= doubles)
+      , testCase "arrayInt"    $ (pfa arrayInt)    >>= (@?= ints)
+      , testCase "arrayFloat"  $ (pfa arrayFloat)  >>= (@?= floats)
+      , testCase "listDouble"  $ (pfl listDouble)  >>= (@?= doubles)
+      , testCase "listInt"     $ (pfl listInt)     >>= (@?= ints)
+      , testCase "listFloat"   $ (pfl listFloat)   >>= (@?= floats)
    ]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -11,7 +11,8 @@ main = defaultMain $ testGroup "Tasty" [
 --                   when doing the CTest.tests.
 --                   SMH it works in the Foreig.C.Types package but not in
 --                   this one, which could be due to the bigger allocations.
---                   Checkout the "travisctests" branch for details.
---                   , CTest.tests
+--
+--                   This branch is intended to test out different options.
+                   , CTest.tests
                    ]
 

--- a/test/libs/c_test.c
+++ b/test/libs/c_test.c
@@ -41,7 +41,7 @@ struct CArrayFloat *arrayFloat (void) {
     }
     return a;
 }
-
+/*
 struct CListDouble *listDouble (void) {
     struct CListDouble *init;
     init = malloc (sizeof (struct CListDouble));
@@ -90,4 +90,4 @@ struct CListFloat *listFloat (void) {
     }
     return init;
 }
-
+*/

--- a/test/libs/c_test.c
+++ b/test/libs/c_test.c
@@ -62,21 +62,21 @@ struct CListDouble *listDouble (void) {
     }
     return init;
 }
-
+*/
 struct CListInt *listInt (void) {
     struct CListInt *init;
-    init = malloc (sizeof (struct CListInt));
+    init = (struct CListInt *) malloc (sizeof (struct CListInt));
 
     struct CListInt *elem = init;
     elem->value = 0;
     for (int i = 1; i < 42; i++) {
-        elem->next = malloc (sizeof (struct CListInt));
+        elem->next = (struct CListInt *) malloc (sizeof (struct CListInt));
         elem = elem->next;
         elem->value = i;
     }
     return init;
 }
-
+/*
 struct CListFloat *listFloat (void) {
     struct CListFloat *init;
     init = malloc (sizeof (struct CListFloat));

--- a/test/libs/c_test.c
+++ b/test/libs/c_test.c
@@ -41,42 +41,60 @@ struct CArrayFloat *arrayFloat (void) {
     }
     return a;
 }
-/*
-struct CListDouble *listDouble (void) {
-    struct CListDouble *init;
-    init = malloc (sizeof (struct CListDouble));
 
+/*
+ * Hasky's linked lists do not have to be allocated in a single space.
+ * In fact Hasky-Types itself allocates memory for each element individually.
+ * However, if the C equivalents are build with individual allocation per element,
+ * on Travis-CI cabal fails with:
+ *
+ *            $ cabal: failed to create OS thread: Cannot allocate memory
+ *
+ * This issue is fixed when allocating the list array like, which is sufficient for
+ * the CI tests.
+ */
+
+struct CListDouble *listDouble (void) {
     int length = 63;
+    struct CListDouble *head;
+    head = malloc (length * sizeof (struct CListDouble));
+
+    // Create array with fibs
     double array[length];
     array[0] = 1.0;
     array[1] = 2.0;
     for (int i = 2; i < length; i++) {
         array[i] = array[i-1] + array[i-2];
     }
-    struct CListDouble *elem = init;
+
+    // Build linked list with data
+    struct CListDouble *elem = head;
     elem->value = array[0];
-    for (int i = 1; i < 63; i++) {
-        elem->next = malloc (sizeof (struct CListDouble));
+    for (int i = 1; i < length; i++) {
+        elem->next = (struct CListDouble *) head+i;
         elem = elem->next;
         elem->value = array[i];
     }
-    return init;
+    elem->next = NULL;
+    return head;
 }
-*/
-struct CListInt *listInt (void) {
-    struct CListInt *init;
-    init = (struct CListInt *) malloc (sizeof (struct CListInt));
 
-    struct CListInt *elem = init;
+struct CListInt *listInt (void) {
+    int length = 42;
+    struct CListInt *head;
+    head = malloc (length * sizeof (struct CListInt));
+
+    struct CListInt *elem = head;
     elem->value = 0;
-    for (int i = 1; i < 42; i++) {
-        elem->next = (struct CListInt *) malloc (sizeof (struct CListInt));
+    for (int i = 1; i < length; i++) {
+        elem->next = (struct CListInt *) head+i;
         elem = elem->next;
         elem->value = i;
     }
-    return init;
+    elem->next = NULL;
+    return head;
 }
-/*
+
 struct CListFloat *listFloat (void) {
     struct CListFloat *init;
     init = malloc (sizeof (struct CListFloat));
@@ -90,4 +108,4 @@ struct CListFloat *listFloat (void) {
     }
     return init;
 }
-*/
+

--- a/test/libs/c_test.c
+++ b/test/libs/c_test.c
@@ -52,9 +52,10 @@ struct CArrayFloat *arrayFloat (void) {
  *
  * This issue is fixed when allocating the list array like, which is sufficient for
  * the CI tests.
+ * To check distributed element linked lists uncomment the specified tests in test/CTest.hs
  */
 
-struct CListDouble *listDouble (void) {
+struct CListDouble *listDoubleTravis (void) {
     int length = 63;
     struct CListDouble *head;
     head = malloc (length * sizeof (struct CListDouble));
@@ -79,7 +80,7 @@ struct CListDouble *listDouble (void) {
     return head;
 }
 
-struct CListInt *listInt (void) {
+struct CListInt *listIntTravis (void) {
     int length = 42;
     struct CListInt *head;
     head = malloc (length * sizeof (struct CListInt));
@@ -95,17 +96,77 @@ struct CListInt *listInt (void) {
     return head;
 }
 
-struct CListFloat *listFloat (void) {
-    struct CListFloat *init;
-    init = malloc (sizeof (struct CListFloat));
+struct CListFloat *listFloatTravis (void) {
+    int length = 21;
+    struct CListFloat *head;
+    head = malloc (length * sizeof (struct CListFloat));
 
-    struct CListFloat *elem = init;
+    struct CListFloat *elem = head;
+    elem->value = 0.0f;
+    for (int i = 1; i < 21; i++) {
+        elem->next = (struct CListFloat *) head+i;
+        elem = elem->next;
+        elem->value = (float) i/2.0;
+    }
+    elem->next = NULL;
+    return head;
+}
+
+/* Below are conventional linked lists which are tested on a
+ * regular basis but ommitted on github due to cabal failing
+ * on the on Travis-CI. (See above)
+ */
+
+struct CListDouble *listDouble (void) {
+    struct CListDouble *head;
+    head = malloc (sizeof (struct CListDouble));
+
+    int length = 63;
+    double array[length];
+    array[0] = 1.0;
+    array[1] = 2.0;
+    for (int i = 2; i < length; i++) {
+        array[i] = array[i-1] + array[i-2];
+    }
+    struct CListDouble *elem = head;
+    elem->value = array[0];
+    for (int i = 1; i < length; i++) {
+        elem->next = malloc (sizeof (struct CListDouble));
+        elem = elem->next;
+        elem->value = array[i];
+    }
+    elem->next = NULL;
+
+    return head;
+}
+
+struct CListInt *listInt (void) {
+    struct CListInt *head;
+    head = malloc (sizeof (struct CListInt));
+
+    struct CListInt *elem = head;
+    elem->value = 0;
+    for (int i = 1; i < 42; i++) {
+        elem->next = malloc (sizeof (struct CListInt));
+        elem = elem->next;
+        elem->value = i;
+    }
+    elem->next = NULL;
+    return head;
+}
+
+struct CListFloat *listFloat (void) {
+    struct CListFloat *head;
+    head = malloc (sizeof (struct CListFloat));
+
+    struct CListFloat *elem = head;
     elem->value = 0.0f;
     for (int i = 1; i < 21; i++) {
         elem->next = malloc (sizeof (struct CListFloat));
         elem = elem->next;
         elem->value = (float) i/2.0;
     }
-    return init;
+    elem->next = NULL;
+    return head;
 }
 

--- a/test/libs/c_test.c
+++ b/test/libs/c_test.c
@@ -42,25 +42,9 @@ struct CArrayFloat *arrayFloat (void) {
     return a;
 }
 
-/*
- * Hasky's linked lists do not have to be allocated in a single space.
- * In fact Hasky-Types itself allocates memory for each element individually.
- * However, if the C equivalents are build with individual allocation per element,
- * on Travis-CI cabal fails with:
- *
- *            $ cabal: failed to create OS thread: Cannot allocate memory
- *
- * This issue is fixed when allocating the list array like, which is sufficient for
- * the CI tests.
- * To check distributed element linked lists uncomment the specified tests in test/CTest.hs
- */
-
-struct CListDouble *listDoubleTravis (void) {
+struct CListDouble *listDouble (void) {
+    // Build array with fibs
     int length = 63;
-    struct CListDouble *head;
-    head = malloc (length * sizeof (struct CListDouble));
-
-    // Create array with fibs
     double array[length];
     array[0] = 1.0;
     array[1] = 2.0;
@@ -68,66 +52,10 @@ struct CListDouble *listDoubleTravis (void) {
         array[i] = array[i-1] + array[i-2];
     }
 
-    // Build linked list with data
-    struct CListDouble *elem = head;
-    elem->value = array[0];
-    for (int i = 1; i < length; i++) {
-        elem->next = (struct CListDouble *) head+i;
-        elem = elem->next;
-        elem->value = array[i];
-    }
-    elem->next = NULL;
-    return head;
-}
-
-struct CListInt *listIntTravis (void) {
-    int length = 42;
-    struct CListInt *head;
-    head = malloc (length * sizeof (struct CListInt));
-
-    struct CListInt *elem = head;
-    elem->value = 0;
-    for (int i = 1; i < length; i++) {
-        elem->next = (struct CListInt *) head+i;
-        elem = elem->next;
-        elem->value = i;
-    }
-    elem->next = NULL;
-    return head;
-}
-
-struct CListFloat *listFloatTravis (void) {
-    int length = 21;
-    struct CListFloat *head;
-    head = malloc (length * sizeof (struct CListFloat));
-
-    struct CListFloat *elem = head;
-    elem->value = 0.0f;
-    for (int i = 1; i < 21; i++) {
-        elem->next = (struct CListFloat *) head+i;
-        elem = elem->next;
-        elem->value = (float) i/2.0;
-    }
-    elem->next = NULL;
-    return head;
-}
-
-/* Below are conventional linked lists which are tested on a
- * regular basis but ommitted on github due to cabal failing
- * on the on Travis-CI. (See above)
- */
-
-struct CListDouble *listDouble (void) {
+    // Build list filled with values of array
     struct CListDouble *head;
     head = malloc (sizeof (struct CListDouble));
 
-    int length = 63;
-    double array[length];
-    array[0] = 1.0;
-    array[1] = 2.0;
-    for (int i = 2; i < length; i++) {
-        array[i] = array[i-1] + array[i-2];
-    }
     struct CListDouble *elem = head;
     elem->value = array[0];
     for (int i = 1; i < length; i++) {

--- a/test/libs/c_test.h
+++ b/test/libs/c_test.h
@@ -35,10 +35,6 @@ struct CArrayDouble *arrayDouble(void);
 struct CArrayInt    *arrayInt(void);
 struct CArrayFloat  *arrayFloat(void);
 
-struct CListDouble *listDoubleTravis(void);
-struct CListInt    *listIntTravis(void);
-struct CListFloat  *listFloatTravis(void);
-
 struct CListDouble *listDouble(void);
 struct CListInt    *listInt(void);
 struct CListFloat  *listFloat(void);

--- a/test/libs/c_test.h
+++ b/test/libs/c_test.h
@@ -20,12 +20,12 @@ struct CListDouble {
     double value;
     struct CListDouble *next;
 };
-
+*/
 struct CListInt {
     int value;
     struct CListInt *next;
 };
-
+/*
 struct CListFloat {
     float value;
     struct CListFloat *next;
@@ -34,9 +34,9 @@ struct CListFloat {
 struct CArrayDouble *arrayDouble(void);
 struct CArrayInt    *arrayInt(void);
 struct CArrayFloat  *arrayFloat(void);
-/*
-struct CListDouble *listDouble(void);
+
+// struct CListDouble *listDouble(void);
 struct CListInt    *listInt(void);
-struct CListFloat  *listFloat(void);
-*/
+// struct CListFloat  *listFloat(void);
+
 #endif // C_TEST

--- a/test/libs/c_test.h
+++ b/test/libs/c_test.h
@@ -35,6 +35,10 @@ struct CArrayDouble *arrayDouble(void);
 struct CArrayInt    *arrayInt(void);
 struct CArrayFloat  *arrayFloat(void);
 
+struct CListDouble *listDoubleTravis(void);
+struct CListInt    *listIntTravis(void);
+struct CListFloat  *listFloatTravis(void);
+
 struct CListDouble *listDouble(void);
 struct CListInt    *listInt(void);
 struct CListFloat  *listFloat(void);

--- a/test/libs/c_test.h
+++ b/test/libs/c_test.h
@@ -15,7 +15,7 @@ struct CArrayFloat {
     int length;
     float *array;
 };
-
+/*
 struct CListDouble {
     double value;
     struct CListDouble *next;
@@ -30,13 +30,13 @@ struct CListFloat {
     float value;
     struct CListFloat *next;
 };
-
+*/
 struct CArrayDouble *arrayDouble(void);
 struct CArrayInt    *arrayInt(void);
 struct CArrayFloat  *arrayFloat(void);
-
+/*
 struct CListDouble *listDouble(void);
 struct CListInt    *listInt(void);
 struct CListFloat  *listFloat(void);
-
+*/
 #endif // C_TEST

--- a/test/libs/c_test.h
+++ b/test/libs/c_test.h
@@ -15,28 +15,28 @@ struct CArrayFloat {
     int length;
     float *array;
 };
-/*
+
 struct CListDouble {
     double value;
     struct CListDouble *next;
 };
-*/
+
 struct CListInt {
     int value;
     struct CListInt *next;
 };
-/*
+
 struct CListFloat {
     float value;
     struct CListFloat *next;
 };
-*/
+
 struct CArrayDouble *arrayDouble(void);
 struct CArrayInt    *arrayInt(void);
 struct CArrayFloat  *arrayFloat(void);
 
-// struct CListDouble *listDouble(void);
+struct CListDouble *listDouble(void);
 struct CListInt    *listInt(void);
-// struct CListFloat  *listFloat(void);
+struct CListFloat  *listFloat(void);
 
 #endif // C_TEST


### PR DESCRIPTION
Adding a NULL pointer as ref of the last element fixes cabal v2-test failing on Travis.